### PR TITLE
fixed a bug, If an empty child in menu

### DIFF
--- a/src/components/views/menu/menu.jsx
+++ b/src/components/views/menu/menu.jsx
@@ -152,6 +152,9 @@ export default class Menu extends React.Component {
     renderChildren() {
         // should deep traverse?
         return React.Children.map(this.props.children, child => {
+            // It may be empty
+            if (!child) return child;
+            
             // Process if a child has menuValue property
             if (typeof child.props.menuValue !== 'undefined') {
                 return React.cloneElement(child, {


### PR DESCRIPTION
```
<Menu>
     {this.renderMyBestItem()}
</Menu>

renderMyBestItem() {
    if (noRederPlz) return null;
   // ...
}
```
I think that a lot of people doing so.

@asvetliakov, this functional maybe need to remove?
```
renderChildren() {
        // should deep traverse?
        return React.Children.map(this.props.children, child => {
            // It may be empty
            if (!child) return child;
            
            // Process if a child has menuValue property
            if (typeof child.props.menuValue !== 'undefined') {
                return React.cloneElement(child, {
                    // If child has active property, then pass it
                    active: (typeof child.props.active !== 'undefined') ? child.props.active : this.isActiveItem(child.props.menuValue),
                    key: child.props.menuValue,
                    onClick: this.onMenuItemClick.bind(this, child.props.menuValue)
                });
            } else {
                // Menu could contain non items, for example divider, pass it untouched (only add key)
                return React.cloneElement(child, {
                    key: (typeof child.key !== 'undefined') ? child.key : child.props.children
                });
            }
        });
    }
```
Because this logic to every project has its own