### PR TITLE
Enforce UNIX/OSX line endings on local checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
+# Define the line ending behavior of the different file extensions
+# Set default behaviour, in case users don't have core.autocrlf set.
 * text=auto
+* text eol=lf


### PR DESCRIPTION
I noticed some Windows line endings (on my Windows machine). This PR should prevent committing CRLF by enforcing LF conversion.

```bash
$ git diff
diff --git a/src/components/views.jsx b/src/components/views.jsx
index 6f0da06..69e99d9 100644
--- a/src/components/views.jsx
+++ b/src/components/views.jsx
@@ -12,3 +12,4 @@ export { default as Event } from './views/feed/event';

 export { default as Item } from './views/item/item';
 export { default as Items } from './views/item/items';
+
warning: CRLF will be replaced by LF in src/components/views.jsx.
The file will have its original line endings in your working directory.

```
