### PR TITLE
Menu: Add fixed, color and left props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -102,7 +102,7 @@ export class Detail extends React.Component<DetailProps, any> {
 // <Labels />
 export interface LabelsProps extends BaseProps<Labels> {
     /**
-     * Labels can share shapes 
+     * Labels can share shapes
      */
     circular?: boolean;
     /**
@@ -462,7 +462,7 @@ export interface ImageProps extends BaseProps<Image> {
      */
     floated?: "right" | "left";
     /**
-     * An image may appear at different sizes 
+     * An image may appear at different sizes
      */
     size?: SizeType;
     /**
@@ -1058,7 +1058,7 @@ export interface MenuProps extends BaseProps<Menu> {
     /**
      * A menu can be fixed to a side of its context
      */
-    fixed?: boolean;
+    fixed?: "top" | "bottom" | "left" | "right" | boolean;
     /**
      * A vertical menu may take the size of its container. (A horizontal menu does this by default)
      */
@@ -1067,6 +1067,10 @@ export interface MenuProps extends BaseProps<Menu> {
      * Float left or right
      */
     floated?: "right" | "left";
+    /**
+     * A menu can have colors
+     */
+    color?: ColorType;
     /**
      * A menu may have its colors inverted to show greater contrast
      */

--- a/src/components/views/menu/__tests__/menu-test.jsx
+++ b/src/components/views/menu/__tests__/menu-test.jsx
@@ -123,12 +123,12 @@ describe('Menu', () => {
     describe('It could be floated', () => {
         it('Left', () => {
             let wrapper = shallow(<Menu floated="left"/>);
-            expect(wrapper).to.have.className('left floated');
+            expect(wrapper).to.have.className('left');
         });
 
         it('Right', () => {
             let wrapper = shallow(<Menu floated="right"/>);
-            expect(wrapper).to.have.className('right floated');
+            expect(wrapper).to.have.className('right');
         });
     });
 

--- a/src/components/views/menu/__tests__/menu-test.jsx
+++ b/src/components/views/menu/__tests__/menu-test.jsx
@@ -12,8 +12,8 @@ describe('Menu', () => {
         let wrapper = shallow(<Menu />);
         expect(wrapper).to.have.tagName('div');
         expect(wrapper).to.have.className('ui menu');
-    });   
-    
+    });
+
     it('It renders as custom component', () => {
         let wrapper = shallow(<Menu component="ul"/>);
         expect(wrapper).to.have.tagName('ul');
@@ -24,72 +24,97 @@ describe('Menu', () => {
         let wrapper = shallow(<Menu borderless/>);
         expect(wrapper).to.have.className('borderless');
     });
-    
+
+    it('Could be colored', () => {
+        let wrapper = shallow(<Menu color="blue"/>);
+        expect(wrapper).to.have.className('blue');
+    });
+
+    it('Could be left fixed', () => {
+        let wrapper = shallow(<Menu fixed="left"/>);
+        expect(wrapper).to.have.className('left fixed');
+    });
+
+    it('Could be right fixed', () => {
+        let wrapper = shallow(<Menu fixed="right"/>);
+        expect(wrapper).to.have.className('right fixed');
+    });
+
+    it('Could be top fixed', () => {
+        let wrapper = shallow(<Menu fixed="top"/>);
+        expect(wrapper).to.have.className('top fixed');
+    });
+
+    it('Could be bottom fixed', () => {
+        let wrapper = shallow(<Menu fixed="bottom"/>);
+        expect(wrapper).to.have.className('bottom fixed');
+    });
+
     it('Could be attached at top', () => {
         let wrapper = shallow(<Menu attached="top"/>);
         expect(wrapper).to.have.className('top attached');
     });
-    
+
     it('Could be attached at bottom', () => {
         let wrapper = shallow(<Menu attached="bottom"/>);
         expect(wrapper).to.have.className('bottom attached');
     });
-    
+
     it('Could be inverted', () => {
         let wrapper = shallow(<Menu inverted/>);
         expect(wrapper).to.have.className('inverted');
     });
-    
+
     it('Could be pagination menu', () => {
         let wrapper = shallow(<Menu pagination/>);
         expect(wrapper).to.have.className('pagination');
     });
-    
+
     it('Could be pointing', () => {
         let wrapper = shallow(<Menu pointing/>);
         expect(wrapper).to.have.className('pointing');
     });
-    
+
     it('Could be secondary', () => {
         let wrapper = shallow(<Menu secondary/>);
         expect(wrapper).to.have.className('secondary');
     });
-    
+
     it('Could be tabular', () => {
         let wrapper = shallow(<Menu tabular/>);
         expect(wrapper).to.have.className('tabular');
     });
-    
+
     it('Could be vertical', () => {
         let wrapper = shallow(<Menu vertical/>);
         expect(wrapper).to.have.className('vertical');
     });
-    
+
     it('Could be fluid', () => {
         let wrapper = shallow(<Menu fluid/>);
         expect(wrapper).to.have.className('fluid');
     });
-    
+
     it('Could be fixed', () => {
         let wrapper = shallow(<Menu fixed/>);
         expect(wrapper).to.have.className('fixed');
     });
-    
+
     it('Could be fitted', () => {
         let wrapper = shallow(<Menu fitted/>);
         expect(wrapper).to.have.className('fitted');
     });
-    
+
     it('Could be fitted horizontally', () => {
         let wrapper = shallow(<Menu fitted="horizontally"/>);
         expect(wrapper).to.have.className('horizontally fitted');
     });
-    
+
     it('Could be fitted vertically', () => {
         let wrapper = shallow(<Menu fitted="vertically"/>);
         expect(wrapper).to.have.className('vertically fitted');
     });
-    
+
     it('Could be text menu', () => {
         let wrapper = shallow(<Menu text/>);
         expect(wrapper).to.have.className('text');
@@ -99,33 +124,33 @@ describe('Menu', () => {
         it('Left', () => {
             let wrapper = shallow(<Menu floated="left"/>);
             expect(wrapper).to.have.className('left floated');
-        }); 
+        });
 
         it('Right', () => {
             let wrapper = shallow(<Menu floated="right"/>);
             expect(wrapper).to.have.className('right floated');
         });
     });
-    
+
     describe('Could be item equal width menu', () => {
         it('Should have <number> item class when even prop was specified', () => {
             let wrapper = shallow(<Menu even><MenuItem /><MenuItem /></Menu>);
             expect(wrapper).to.have.className('item menu two');
         });
-        
+
         it('Shouldn\'t have <number> item calss when there are no MenuItems childs', () => {
             let wrapper = shallow(<Menu even />);
             expect(wrapper).to.have.not.className('item');
         });
     });
-    
+
     describe('Shouldn\'t have default ui class', () => {
         it('When menu is a child of another menu', () => {
             let wrapper = shallow(<Menu><Menu /></Menu>);
             expect(wrapper).to.have.className('ui');
             expect(wrapper.children()).to.have.not.className('ui');
         });
-        
+
         it('When menu is a child of dropdown', () => {
             let wrapper = shallow(<Menu />, { context: { isDropdownChild: true } });
             expect(wrapper).to.have.not.className('ui');
@@ -183,26 +208,26 @@ describe('Menu', () => {
             expect(onMenuItemClickStub).to.have.not.been.called;
         });
     });
-    
+
     describe('When menuValue property provided', () => {
         let childrens = [];
         childrens.push(<MenuItem className="first"
-                                 key={1} 
+                                 key={1}
                                  menuValue={1}
                        >First</MenuItem>
         );
         childrens.push(<MenuItem className="second"
-                                 key={2} 
+                                 key={2}
                                  menuValue={2}
                        >Second</MenuItem>
         );
         childrens.push(<MenuItem className="third"
-                                 key={3} 
+                                 key={3}
                                  menuValue={3}
                        >Third</MenuItem>
         );
-        
-        
+
+
         it('Should render MenuItem as active when MenuItem value is matched by provided value', () => {
             let wrapper = shallow(<Menu menuValue={1}>{childrens}</Menu>);
             expect(wrapper.find(MenuItem).at(0)).to.have.prop('active', true);

--- a/src/components/views/menu/menu.jsx
+++ b/src/components/views/menu/menu.jsx
@@ -86,14 +86,6 @@ export default class Menu extends React.Component {
          */
         pointing: React.PropTypes.bool,
         /**
-         * A menu can be formatted to float left
-         */
-        left: React.PropTypes.bool,
-        /**
-         * A menu can be formatted to float right
-         */
-        right: React.PropTypes.bool,
-        /**
          * A menu can adjust its appearance to de-emphasize its contents
          */
         secondary: React.PropTypes.bool,
@@ -187,7 +179,7 @@ export default class Menu extends React.Component {
     render() {
         /* eslint-disable no-use-before-define */
         let { attached, borderless, color, component, even, fitted, fixed, fluid, floated, inverted, pagination,
-            pointing, left, right, secondary, tabular, text, menuValue, vertical, ...other } = this.props;
+            pointing, secondary, tabular, text, menuValue, vertical, ...other } = this.props;
         /* eslint-enable no-use-before-define */
 
         other.className = classNames(this.props.className, this.getClasses());
@@ -228,8 +220,8 @@ export default class Menu extends React.Component {
             // numbers
 
             // position
-            left: this.props.left,
-            right: this.props.right,
+            left: false,
+            right: false,
             top: false,
             bottom: false,
 
@@ -258,6 +250,7 @@ export default class Menu extends React.Component {
         };
 
         classes[this.props.color] = !!this.props.color;
+        classes[this.props.floated] = !!this.props.floated;
 
         if (this.props.even && childCount > 0) {
             if (childCount > 0  && childCount <= 12) {

--- a/src/components/views/menu/menu.jsx
+++ b/src/components/views/menu/menu.jsx
@@ -5,6 +5,7 @@ import DefaultProps from '../../defaultProps';
 
 let validProps = {
     attached: ['top', 'bottom'],
+    fixed: ['top', 'bottom', 'right', 'left'],
     fitted: ['horizontally', 'vertically'],
     floated: ['right', 'left']
 };
@@ -38,7 +39,10 @@ export default class Menu extends React.Component {
         /**
          * A menu can be fixed to a side of its context
          */
-        fixed: React.PropTypes.bool,
+        fixed: React.PropTypes.oneOfType([
+            React.PropTypes.bool,
+            React.PropTypes.oneOf(['right', 'left', 'top', 'bottom'])
+        ]),
         /**
          * Float left or right
          */
@@ -47,6 +51,10 @@ export default class Menu extends React.Component {
          * A vertical menu may take the size of its container. (A horizontal menu does this by default)
          */
         fluid: React.PropTypes.bool,
+        /**
+         * A menu can be formatted with different colors
+         */
+        color: React.PropTypes.string,
         /**
          * A menu may have its colors inverted to show greater contrast
          */
@@ -66,7 +74,7 @@ export default class Menu extends React.Component {
          */
         onMenuChange: React.PropTypes.func,
         /**
-         * Callback for menu item click 
+         * Callback for menu item click
          */
         onMenuItemClick: React.PropTypes.func,
         /**
@@ -77,6 +85,10 @@ export default class Menu extends React.Component {
          * A menu can point to show its relationship to nearby content
          */
         pointing: React.PropTypes.bool,
+        /**
+         * A menu can be formatted to float left
+         */
+        left: React.PropTypes.bool,
         /**
          * A menu can be formatted to float right
          */
@@ -113,22 +125,22 @@ export default class Menu extends React.Component {
         onMenuItemClick: () => {},
         onMenuChange: () => {}
     };
-    
+
     constructor(props) {
         super(props);
     }
-    
+
     getChildContext() {
         return {
             isMenuChild: true
         };
     }
-    
+
 
     onMenuItemClick(value, event) {
         event.stopPropagation();
         event.preventDefault();
-        
+
         this.props.onMenuItemClick(value);
         // Call onMenuChange callback when needed
         if (typeof this.props.menuValue !== 'undefined') {
@@ -141,20 +153,20 @@ export default class Menu extends React.Component {
                     // select menu item
                     this.props.onMenuChange([...this.props.menuValue, value]);
                 }
-                // Single menu selection 
+                // Single menu selection
             } else {
                 // calling with null if clicking on same item, because we might want to unselect menu item
                 this.props.onMenuChange(this.props.menuValue !== value ? value : null);
             }
         }
     }
-    
+
     renderChildren() {
         // should deep traverse?
         return React.Children.map(this.props.children, child => {
             // It may be empty
             if (!child) return child;
-            
+
             // Process if a child has menuValue property
             if (typeof child.props.menuValue !== 'undefined') {
                 return React.cloneElement(child, {
@@ -174,8 +186,8 @@ export default class Menu extends React.Component {
 
     render() {
         /* eslint-disable no-use-before-define */
-        let { attached, borderless, component, even, fitted, fixed, fluid, floated, inverted, pagination,
-            pointing, right, secondary, tabular, text, menuValue, vertical, ...other } = this.props;
+        let { attached, borderless, color, component, even, fitted, fixed, fluid, floated, inverted, pagination,
+            pointing, left, right, secondary, tabular, text, menuValue, vertical, ...other } = this.props;
         /* eslint-enable no-use-before-define */
 
         other.className = classNames(this.props.className, this.getClasses());
@@ -185,7 +197,7 @@ export default class Menu extends React.Component {
         } else {
             component = this.props.component;
         }
-        
+
         let children = this.renderChildren();
 
         return React.createElement(
@@ -205,7 +217,7 @@ export default class Menu extends React.Component {
         if (Array.isArray(this.props.menuValue) && this.props.menuValue.indexOf(value) !== -1) return true;
         return !!(!Array.isArray(this.props.menuValue) && this.props.menuValue === value);
     }
-    
+
     getClasses() {
         let childCount = React.Children.count(this.props.children);
 
@@ -216,6 +228,7 @@ export default class Menu extends React.Component {
             // numbers
 
             // position
+            left: this.props.left,
             right: this.props.right,
             top: false,
             bottom: false,
@@ -243,6 +256,8 @@ export default class Menu extends React.Component {
             // component
             menu: this.props.defaultClasses
         };
+
+        classes[this.props.color] = !!this.props.color;
 
         if (this.props.even && childCount > 0) {
             if (childCount > 0  && childCount <= 12) {


### PR DESCRIPTION
- Allow `fixed` to be passed a position (`<Menu fixed="left"`)
- Add `color` prop (`<Menu color="blue">`)
- Add `left` prop  (`<Menu left>`)

PS: don’t know why this is changing so many lines, I have the same settings as the `.editorconfig` file:
![](https://dl.dropboxusercontent.com/spa/tqch4axi0t55dpk/a3e09bs8.png)