### PR TITLE
Header, Modal fixes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1457,7 +1457,7 @@ export interface ModalProps extends BaseProps<Modal> {
      */
     fullscreen?: boolean;
     /**
-     * Scrolling content
+     * Scrolling content. This flag will be set automatically if modal's content is too big
      */
     scrolling?: boolean;
     /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1459,7 +1459,7 @@ export interface ModalProps extends BaseProps<Modal> {
     /**
      * Scrolling content
      */
-    scrooling?: boolean;
+    scrolling?: boolean;
     /**
      * A modal can vary in size
      */

--- a/index.d.ts
+++ b/index.d.ts
@@ -1479,6 +1479,11 @@ export interface ModalProps extends BaseProps<Modal> {
     /**
      * Callback from outside modal click
      */
-    onRequestClose: () => void;
+    onRequestClose?: () => void;
+    /**
+     * Overlay zIndex
+     * @default 1000
+     */
+    zIndex?: number;
 }
 export class Modal extends React.Component<ModalProps, any> { }

--- a/src/components/elements/header/__tests__/header-test.jsx
+++ b/src/components/elements/header/__tests__/header-test.jsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import {expect} from 'chai';
-import {shallow} from 'enzyme';
+import {shallow, mount} from 'enzyme';
 import {itShouldConsumeOwnAndPassCustomProps} from '../../../test-utils';
 import Icon from '../../icon/icon';
 import Image from '../../image/image';
@@ -197,6 +197,17 @@ describe('Header', () => {
             expect(wrapper).to.have.className('ui');
         });
     });
+    
+    // Use full dom rendering here since we need context of header inside in header
+    describe('When header inside another header', () => {
+        it('Should has sub class name', () => {
+            let wrapper = mount(
+                <Header><Header/></Header>
+            );
+            expect(wrapper.childAt(0)).to.have.className('sub');
+            expect(wrapper.childAt(0)).to.have.not.className('ui');
+        });
+    })
 
     itShouldConsumeOwnAndPassCustomProps(Header, consumedProps);
 });

--- a/src/components/elements/header/__tests__/header-test.jsx
+++ b/src/components/elements/header/__tests__/header-test.jsx
@@ -1,10 +1,11 @@
 /* eslint-env node, mocha */
 
 import React from 'react';
-import { expect } from 'chai';
-import { shallow } from 'enzyme';
-import { itShouldConsumeOwnAndPassCustomProps } from '../../../test-utils';
-import Icon from './../../icon/icon';
+import {expect} from 'chai';
+import {shallow} from 'enzyme';
+import {itShouldConsumeOwnAndPassCustomProps} from '../../../test-utils';
+import Icon from '../../icon/icon';
+import Image from '../../image/image';
 import Header from '../header';
 
 
@@ -35,72 +36,72 @@ describe('Header', () => {
         });
 
         it('renders as a custom HTML element', () => {
-            let wrapper = shallow(<Header component="h1" />);
+            let wrapper = shallow(<Header component="h1"/>);
             expect(wrapper).to.have.tagName('h1');
         });
     });
 
     describe('should allow emphasis', () => {
         it('has a dividing emphasis', () => {
-            let wrapper = shallow(<Header emphasis="dividing" />);
+            let wrapper = shallow(<Header emphasis="dividing"/>);
             expect(wrapper).to.have.className('dividing');
         });
 
         it('has a block emphasis', () => {
-            let wrapper = shallow(<Header emphasis="block" />);
+            let wrapper = shallow(<Header emphasis="block"/>);
             expect(wrapper).to.have.className('block');
         });
     });
 
     describe('should float', () => {
         it('floats right', () => {
-            let wrapper = shallow(<Header floated="right" />);
+            let wrapper = shallow(<Header floated="right"/>);
             expect(wrapper).to.have.className('right floated');
         });
 
         it('floats left', () => {
-            let wrapper = shallow(<Header floated="left" />);
+            let wrapper = shallow(<Header floated="left"/>);
             expect(wrapper).to.have.className('left floated');
         });
     });
 
     describe('should attach to other objects', () => {
         it('can attach to the top of an attachable element', () => {
-            let wrapper = shallow(<Header attached="top" />);
+            let wrapper = shallow(<Header attached="top"/>);
             expect(wrapper).to.have.className('top attached');
             expect(wrapper).to.have.tagName('div');
         });
 
         it('can attach to the bottom of an attachable element', () => {
-            let wrapper = shallow(<Header attached="bottom" />);
+            let wrapper = shallow(<Header attached="bottom"/>);
             expect(wrapper).to.have.className('bottom attached');
             expect(wrapper).to.have.tagName('div');
         });
     });
 
     it('should be noticable on dark backgrounds', () => {
-        let wrapper = shallow(<Header inverted />);
+        let wrapper = shallow(<Header inverted/>);
         expect(wrapper).to.have.className('inverted');
     });
 
     it('should appear disabled', () => {
-        let wrapper = shallow(<Header disabled />);
+        let wrapper = shallow(<Header disabled/>);
         expect(wrapper).to.have.className('disabled');
     });
 
     it('should be a dividing header', () => {
-        let wrapper = shallow(<Header divider />);
+        let wrapper = shallow(<Header divider/>);
         expect(wrapper).to.have.className('divider');
     });
 
     it('should have various sizes', () => {
-        let wrapper = shallow(<Header size="small" />);
+        let wrapper = shallow(<Header size="small"/>);
         expect(wrapper).to.have.className('small');
         expect(wrapper).to.have.not.className('size');
     });
 
     it('should support colors', () => {
-        let wrapper = shallow(<Header color="yellow" />);
+        let wrapper = shallow(<Header color="yellow"/>);
         expect(wrapper).to.have.className('yellow');
         expect(wrapper).to.have.not.className('color');
     });
@@ -110,24 +111,24 @@ describe('Header', () => {
             let wrapper = shallow(<Header aligned="right"/>);
             expect(wrapper).to.have.className('right aligned');
         });
-        
+
         it('left', () => {
             let wrapper = shallow(<Header aligned="left"/>);
             expect(wrapper).to.have.className('left aligned');
         });
-        
+
         it('justified', () => {
             let wrapper = shallow(<Header aligned="justified"/>);
             expect(wrapper).to.have.className('justified');
             expect(wrapper).to.have.not.className('aligned');
         });
-        
+
         it('center', () => {
             let wrapper = shallow(<Header aligned="center"/>);
             expect(wrapper).to.have.className('center aligned');
         });
     });
-    
+
     describe('It could be icon header', () => {
         it('Renders as icon header', () => {
             let wrapper = shallow(<Header icon="users"/>);
@@ -135,7 +136,7 @@ describe('Header', () => {
             expect(wrapper.find(Icon)).to.be.exist;
             expect(wrapper.find(Icon)).to.have.prop('name', 'users');
         });
-        
+
         it('Allows to use custom icon component', () => {
             let wrapper = shallow(<Header icon="users" iconComponent={(props) => <Icon circular {...props}/>}/>);
             expect(wrapper).to.have.className('ui icon header');
@@ -145,40 +146,54 @@ describe('Header', () => {
             expect(iconComponent).to.have.prop('circular', true);
         });
     });
-    
+
     it('Could be used as menu item', () => {
-        let wrapper = shallow(<Header item/>, { context: { isMenuChild: true } });
+        let wrapper = shallow(<Header item/>, {context: {isMenuChild: true}});
         expect(wrapper).to.have.className('item');
     });
-    
+
     describe('It doesn\'t render ui class name', () => {
         it('When in context of list', () => {
-            let wrapper = shallow(<Header/>, { context: { isListChild: true } });
+            let wrapper = shallow(<Header/>, {context: {isListChild: true}});
             expect(wrapper).to.have.not.className('ui')
         });
-        
+
         it('When in context of another header', () => {
-            let wrapper = shallow(<Header/>, { context: { isHeaderChild: true } });
+            let wrapper = shallow(<Header/>, {context: {isHeaderChild: true}});
             expect(wrapper).to.have.not.className('ui')
         });
-        
+
         it('WHen in context of menu', () => {
-            let wrapper = shallow(<Header/>, { context: { isMenuChild: true } });
+            let wrapper = shallow(<Header/>, {context: {isMenuChild: true}});
             expect(wrapper).to.have.not.className('ui')
         });
-        
+
         it('When in context of card', () => {
-            let wrapper = shallow(<Header/>, { context: { isCardChild: true } });
+            let wrapper = shallow(<Header/>, {context: {isCardChild: true}});
             expect(wrapper).to.have.not.className('ui')
         });
-        
+
         it('When in context of modal', () => {
-            let wrapper = shallow(<Header/>, { context: { isModalChild: true } });
+            let wrapper = shallow(<Header/>, {context: {isModalChild: true}});
             expect(wrapper).to.have.not.className('ui')
         });
-        
+
         it('Renders ui class name when in context of modal and icon header', () => {
-            let wrapper = shallow(<Header icon="users"/>, { context: { isModalChild: true } });
+            let wrapper = shallow(<Header icon="users"/>, {context: {isModalChild: true}});
+            expect(wrapper).to.have.className('ui');
+        });
+
+        it('Renders ui class name when in context of modal and header has image or icon content', () => {
+            let wrapper = shallow(
+                <Header><Icon name="users"/>Test</Header>,
+                {context: {isModalChild: true}}
+            );
+            expect(wrapper).to.have.className('ui');
+
+            wrapper = shallow(
+                <Header><Image src="http://test.com"/>Test</Header>,
+                {context: {isModalChild: true}}
+            );
             expect(wrapper).to.have.className('ui');
         });
     });

--- a/src/components/elements/header/examples/header.examples.md
+++ b/src/components/elements/header/examples/header.examples.md
@@ -24,7 +24,7 @@
     <Header size="tiny" icon="settings">
         <Content>
             Account settings
-            <SubHeader>Manage your account settings and set e-mail preference</SubHeader>
+            <Header>Manage your account settings and set e-mail preference</Header>
         </Content>
     </Header>
 
@@ -67,7 +67,7 @@ This is slightly differ from icon header
             <Image src="http://semantic-ui.com/images/icons/plugin.png"/>
             <Content>
                 Plug-ins
-                <SubHeader>Check out our plug-in marketplace</SubHeader>
+                <Header>Check out our plug-in marketplace</Header>
             </Content>
         </Header>
      </div>

--- a/src/components/elements/header/examples/subheader.examples.md
+++ b/src/components/elements/header/examples/subheader.examples.md
@@ -1,4 +1,5 @@
 ## SubHeader
+## Deprecated, use just Header inside another Header instead
 Almost like header
 
     <div>

--- a/src/components/elements/header/header.jsx
+++ b/src/components/elements/header/header.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import classNames from 'classnames';
 import elementType from 'react-prop-types/lib/elementType';
-import { validateClassProps } from '../../utilities';
+import { validateClassProps, hasChild } from '../../utilities';
 import DefaultProps from '../../defaultProps';
-import Icon from './../icon/icon';
+import Icon from '../icon/icon';
+import Image from '../image/image';
 
 let validProps = {
     aligned: ['right', 'left', 'justified', 'center'],
@@ -91,7 +92,8 @@ export default class Header extends React.Component {
 
     /* eslint-disable */
     static Components = {
-        Icon: Icon
+        Icon: Icon,
+        Image: Image
     }
     /* eslint-enable */
 
@@ -129,16 +131,37 @@ export default class Header extends React.Component {
         );
 
     }
+    
+    shouldHaveUiClass() {
+        if (!this.props.defaultClasses) {
+            return false;
+        }
+        if (this.context.isListChild || this.context.isHeaderChild || 
+            this.context.isMenuChild || this.context.isCardChild
+        ) {
+            return false;
+        }
+        
+        // Modal header shouldn't have ui class only for simple modals, i.e. icon header or header with image/icon 
+        // content should HAS ui class
+        if (this.context.isModalChild) {
+            // Icon header
+            if (this.props.icon) {
+                return true;
+            }
+            // Header with icon / image content should has UI class
+            if (hasChild(this.props.children, Header.Components.Icon) || hasChild(this.props.children, Header.Components.Image)) {
+                return true;
+            }
+            return false;
+        }
+        return true;
+    }
 
     getClasses() {
         let classes = {
             // default
-            ui: this.props.defaultClasses && 
-                !this.context.isListChild && 
-                !this.context.isHeaderChild && 
-                !this.context.isMenuChild && 
-                !this.context.isCardChild && 
-                !(this.context.isModalChild && !this.props.icon),
+            ui: this.shouldHaveUiClass(),
 
             // types
             icon: this.props.icon,

--- a/src/components/elements/header/header.jsx
+++ b/src/components/elements/header/header.jsx
@@ -180,6 +180,7 @@ export default class Header extends React.Component {
             horizontal: this.props.horizontal,
             inverted: this.props.inverted,
 
+            sub: this.context.isHeaderChild && this.props.defaultClasses,
             // component
             header: this.props.defaultClasses
         };

--- a/src/components/elements/header/subheader.jsx
+++ b/src/components/elements/header/subheader.jsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 
 /**
  * Sub header, same as header but with 'sub' class name
+ * Deprecated
  */
 let SubHeader = (props) => {
     const { component, children, defaultClasses, ...other } = props;

--- a/src/components/elements/label/__tests__/label-test.jsx
+++ b/src/components/elements/label/__tests__/label-test.jsx
@@ -118,12 +118,12 @@ describe('Label', () => {
         });
         
         it('top', () => {
-            let wrapper = shallow(<Label pointing="below"/>);
+            let wrapper = shallow(<Label pointing="top"/>);
             expect(wrapper).to.have.className('top pointing');
         });
         
         it('bottom', () => {
-            let wrapper = shallow(<Label pointing="below"/>);
+            let wrapper = shallow(<Label pointing="bottom"/>);
             expect(wrapper).to.have.className('bottom pointing');
         });
         

--- a/src/components/modules/modal/modal.jsx
+++ b/src/components/modules/modal/modal.jsx
@@ -29,7 +29,11 @@ export default class Modal extends React.Component {
         /**
          * Callback from outside modal click
          */
-        onRequestClose: React.PropTypes.func
+        onRequestClose: React.PropTypes.func,
+        /**
+         * Overlay zIndex
+         */
+        zIndex: React.PropTypes.number
     };
 
 
@@ -47,7 +51,8 @@ export default class Modal extends React.Component {
             scale: 0.5,
             opacity: 0.5
         },
-        onRequestClose: () => { }
+        onRequestClose: () => { },
+        zIndex: 1000
     };
 
     /* eslint-disable */
@@ -132,7 +137,7 @@ export default class Modal extends React.Component {
 
     render() {
 
-        const { component, enterAnimation, leaveAnimation, children, dimmed, onOutsideClick, style, ...other } = this.props;
+        const { component, enterAnimation, leaveAnimation, children, dimmed, onOutsideClick, style, zIndex, ...other } = this.props;
 
         // Apply layer to portal to prevent clicking outside
         const portalStyle = {
@@ -140,7 +145,8 @@ export default class Modal extends React.Component {
             top: 0,
             bottom: 0,
             left: 0,
-            right: 0
+            right: 0,
+            zIndex: zIndex
         };
 
         const modalPosition = {

--- a/src/components/radium.jsx
+++ b/src/components/radium.jsx
@@ -255,6 +255,7 @@ RadiumSocialButton.Components.Button = RadiumButton;
 RadiumSocialButton.Components.Icon = RadiumIcon;
 
 RadiumHeader.Components.Icon = RadiumIcon;
+RadiumHeader.Components.Image = RadiumImage;
 RadiumSubHeader.Components.Header = RadiumHeader;
 
 RadiumInput.Components.Icon = RadiumIcon;


### PR DESCRIPTION
1) Deprecated SubHeader, now any Header inside in Header will get sub class
2) Header: render ui class name if child of modal and has Icon or Image content
3) Modal: Added zIndex prop (default 1000) to portal overlay