### PR TITLE
Wrap Popup elements in a renderable element within Portal

### DIFF
--- a/src/components/modules/popup/popup.jsx
+++ b/src/components/modules/popup/popup.jsx
@@ -201,7 +201,7 @@ export default class Popup extends React.Component {
             <Portal isOpened={this.state.active || (!this.state.active && this.state.closing)}
                     style={this.props.preventElementClicks ? portalStyle : {}}
             >
-                <noscript>
+                <div>
                     <EventListener elementName="document"
                                    onMouseDown={this.onOutsideClick.bind(this)}
                                    onTouchStart={this.onOutsideClick.bind(this)}/>
@@ -222,7 +222,7 @@ export default class Popup extends React.Component {
                             style={popupStyle}/>
                         }
                     </Transition>
-                </noscript>
+                </div>
             </Portal>
         );
     }

--- a/src/components/modules/popup/popup.jsx
+++ b/src/components/modules/popup/popup.jsx
@@ -201,28 +201,28 @@ export default class Popup extends React.Component {
             <Portal isOpened={this.state.active || (!this.state.active && this.state.closing)}
                     style={this.props.preventElementClicks ? portalStyle : {}}
             >
-                <div>
+                <EventListener elementName="window"
+                               onResize={this.handleResize}
+                               onScroll={this.handleScroll}>
                     <EventListener elementName="document"
                                    onMouseDown={this.onOutsideClick.bind(this)}
-                                   onTouchStart={this.onOutsideClick.bind(this)}/>
-                    <EventListener elementName="window"
-                                   onResize={this.handleResize}
-                                   onScroll={this.handleScroll}/>
-                    <Transition
-                        component={false}
-                        enter={startAnimation}
-                        leave={endAnimation}
-                    >
-                        {(this.state.active && !this.state.closing) &&
-                        <Popup.Components.PopupElement
-                            {...other}
-                            key="popup"
-                            position={this.state.position}
-                            ref="popup"
-                            style={popupStyle}/>
-                        }
-                    </Transition>
-                </div>
+                                   onTouchStart={this.onOutsideClick.bind(this)}>
+                        <Transition
+                            component={false}
+                            enter={startAnimation}
+                            leave={endAnimation}
+                        >
+                            {(this.state.active && !this.state.closing) &&
+                            <Popup.Components.PopupElement
+                                {...other}
+                                key="popup"
+                                position={this.state.position}
+                                ref="popup"
+                                style={popupStyle}/>
+                            }
+                        </Transition>
+                    </EventListener>
+                </EventListener>
             </Portal>
         );
     }


### PR DESCRIPTION
We have struggled quite a bit with `Popup` components not displaying, only to discover that they were wrapped within a `<noscript>` tag (apparently as a consequence of 7aed8baa).

This change aims at fixing this, by wrapping them within a tag that is actually renderable (`Portal` requires a single root element).

I chose `<div>` and it fixed the display issue on our side, but please advise if a different tag or component should be used instead.